### PR TITLE
Test if POST reply looks like SOAP, if not, raise for status

### DIFF
--- a/suds_requests.py
+++ b/suds_requests.py
@@ -50,6 +50,9 @@ class RequestsTransport(transport.Transport):
             data=request.message,
             headers=request.headers,
         )
+        if resp.headers.get('content-type') not in ('text/xml',
+                                                    'application/soap+xml'):
+            resp.raise_for_status()
         return transport.Reply(
             resp.status_code,
             resp.headers,


### PR DESCRIPTION
Noticed today in TA that also POST responses aren't handled properly. These
are more complex as certain error HTTP response codes may be generated with
SOAP faults. Hence, check content-type first and only if the response doesn't
look like SOAP, raise for HTTP response code
