### PR TITLE
Better error reporting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='suds_requests',
-    version='0.3.1',
+    version='0.3',
     description='A suds transport implemented with requests',
     long_description=open('README.rst').read(),
     author='Jason Michalski',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='suds_requests',
-    version='0.3',
+    version='0.3.1',
     description='A suds transport implemented with requests',
     long_description=open('README.rst').read(),
     author='Jason Michalski',

--- a/suds_requests.py
+++ b/suds_requests.py
@@ -25,9 +25,11 @@ def handle_errors(f):
                 buf,
             )
         except requests.RequestException:
+            buf = StringIO.StringIO(traceback.format_exc())
             raise transport.TransportError(
                 'Error in requests\n' + traceback.format_exc(),
                 000,
+                buf,
             )
     return wrapper
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -35,3 +35,4 @@ def test_RequestException():
     with pytest.raises(suds.transport.TransportError) as excinfo:
         f()
     assert excinfo.value.httpcode == 000
+    assert excinfo.value.fp.read().startswith('Traceback')


### PR DESCRIPTION
suds would fail in case of a network error with an unrelated
error message ('NoneType' object has no attribute 'read') in
the suds client. This patch makes the failure explicit.